### PR TITLE
Adding constant climate scenario

### DIFF
--- a/src/biosimclient/BioSimEnums.java
+++ b/src/biosimclient/BioSimEnums.java
@@ -34,7 +34,11 @@ public final class BioSimEnums {
 		/**
 		 * RCP 8.5
 		 */
-		RCP85("8_5");
+		RCP85("8_5"),
+		/**
+		 * Constant climate based on 1991-2020 normals
+		 */
+		CONSTANT_CLIMATE("ConstantClimate");
 		
 		private final String urlString;
 		RCP(String urlString) {

--- a/test/biosimclient/BioSimClientPastAndFutureDailyClimateTest.java
+++ b/test/biosimclient/BioSimClientPastAndFutureDailyClimateTest.java
@@ -52,13 +52,14 @@ public class BioSimClientPastAndFutureDailyClimateTest {
 	/*
 	 * Tests if the weather generation over past and future time intervals.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
-	public void testingWithDailyOverlappingPastAndFuture() throws BioSimClientException, BioSimServerException {
+	public void test01WithDailyOverlappingPastAndFuture() throws BioSimClientException, BioSimServerException {
 		List<BioSimPlot> locations = BioSimClientNormalsTest.getPlots();
 		int initialDateYr = 2000;
 		String modelName = "DegreeDay_Annual";
-		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
-		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs2 = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs2 = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
 		
 		for (BioSimPlot plot : teleIORefs.keySet()) {
 			BioSimDataSet firstDataSet = teleIORefs.get(plot);
@@ -99,15 +100,16 @@ public class BioSimClientPastAndFutureDailyClimateTest {
 	/*
 	 * Tests future climate with default climate model and RCP.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
-	public void testingFutureDegreeDaysWithDefaultValuesOfRCPsandClimateModels() throws BioSimClientException, BioSimServerException {
+	public void test02FutureDegreeDaysWithDefaultValuesOfRCPsandClimateModels() throws BioSimClientException, BioSimServerException {
 		List<BioSimPlot> locations = BioSimClientNormalsTest.getPlots();
 		int initialDateYr = 2090;
 		int finalDateYr = 2091;
 		String modelName = "DegreeDay_Annual";
-		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP45def_RCM4def = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
-		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP45_RCM4def = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, RCP.RCP45, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
-		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP45def_RCM4 = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, null, ClimateModel.RCM4, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP45def_RCM4def = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP45_RCM4def = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, RCP.RCP45, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP45def_RCM4 = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, null, ClimateModel.RCM4, Arrays.asList(new String[]{modelName}), null).get(modelName);
 		
 		for (BioSimPlot plot : oRCP45def_RCM4def.keySet()) {
 			BioSimDataSet firstDataSet = oRCP45def_RCM4def.get(plot);
@@ -147,14 +149,15 @@ public class BioSimClientPastAndFutureDailyClimateTest {
 	/*
 	 * Tests future climate with RCP 8.5 and default climate model.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
-	public void testingFutureDegreeDaysWithRCP85andClimateModels() throws BioSimClientException, BioSimServerException {
+	public void test03FutureDegreeDaysWithRCP85andClimateModels() throws BioSimClientException, BioSimServerException {
 		List<BioSimPlot> locations = BioSimClientNormalsTest.getPlots();
 		int initialDateYr = 2090;
 		int finalDateYr = 2091;
 		String modelName = "DegreeDay_Annual";
-		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP85_RCM4def = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, RCP.RCP85, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
-		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP85_RCM4 = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, RCP.RCP85, ClimateModel.RCM4, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP85_RCM4def = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, RCP.RCP85, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> oRCP85_RCM4 = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, finalDateYr, locations, RCP.RCP85, ClimateModel.RCM4, Arrays.asList(new String[]{modelName}), null).get(modelName);
 		
 		for (BioSimPlot plot : oRCP85_RCM4def.keySet()) {
 			BioSimDataSet firstDataSet = oRCP85_RCM4def.get(plot);
@@ -185,8 +188,9 @@ public class BioSimClientPastAndFutureDailyClimateTest {
 	/*
 	 * Tests if the weather generation over past and future time intervals.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
-	public void testingWithForceClimateGenerationEnabled() throws BioSimClientException, BioSimServerException {
+	public void test04WithForceClimateGenerationEnabled() throws BioSimClientException, BioSimServerException {
 		BioSimClient.setForceClimateGenerationEnabled(true);
 		List<BioSimPlot> locations = new ArrayList<BioSimPlot>();
 		locations.add(BioSimClientNormalsTest.getPlots().get(0));
@@ -194,8 +198,8 @@ public class BioSimClientPastAndFutureDailyClimateTest {
 		int initialDateYr = 2000;
 		
 		String modelName = "DegreeDay_Annual"; 
-		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
-		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs2 = (LinkedHashMap) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
+		LinkedHashMap<BioSimPlot, BioSimDataSet> teleIORefs2 = (LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(initialDateYr, 2040, locations, null, null, Arrays.asList(new String[]{modelName}), null).get(modelName);
 		
 		for (BioSimPlot plot : teleIORefs.keySet()) {
 			BioSimDataSet firstDataSet = teleIORefs.get(plot);
@@ -223,6 +227,55 @@ public class BioSimClientPastAndFutureDailyClimateTest {
 		BioSimClient.setForceClimateGenerationEnabled(false);		// set it back to default value 
 		
 	}
+	
+	/*
+	 * Tests if the weather generation over past and future time intervals.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void test05WithFutureConstantClimate() throws BioSimClientException, BioSimServerException {
+		List<BioSimPlot> locations = new ArrayList<BioSimPlot>();
+		BioSimPlot refPlot = BioSimClientNormalsTest.getPlots().get(0); 
+		locations.add(refPlot);
+
+		String modelName = "DegreeDay_Annual"; 
+		BioSimDataSet pastClimate = ((LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(2000, 2010, locations, RCP.CONSTANT_CLIMATE, null, Arrays.asList(new String[]{modelName}), null)
+				.get(modelName)).get(refPlot);
+		BioSimDataSet futureClimateUnderConstantClimate = ((LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(2080, 2090, locations, RCP.CONSTANT_CLIMATE, null, Arrays.asList(new String[]{modelName}), null)
+				.get(modelName)).get(refPlot);
+		BioSimDataSet futureClimateRCP4_5 = ((LinkedHashMap<BioSimPlot, BioSimDataSet>) BioSimClient.generateWeather(2080, 2090, locations, RCP.RCP45, null, Arrays.asList(new String[]{modelName}), null)
+				.get(modelName)).get(refPlot);
+		
+		int indexDD = pastClimate.getFieldNames().indexOf("DD");
+		if (indexDD == -1) {
+			throw new UnsupportedOperationException("The field DD cannot be found in the BioSimDataSet instance!");
+		}
+		
+		double pastMean = 0d;
+		double futureMeanConstantClimate = 0d;
+		double futureMeanRCP4_5 = 0d;
+		
+		Assert.assertTrue("Checking all dataset instances have the same number of observations",
+				pastClimate.getNumberOfObservations() == futureClimateUnderConstantClimate.getNumberOfObservations());
+		Assert.assertTrue("Checking all dataset instances have the same number of observations",
+				pastClimate.getNumberOfObservations() == futureClimateRCP4_5.getNumberOfObservations());
+
+		for (int i = 0; i < pastClimate.getNumberOfObservations(); i++) {
+			pastMean += (Double) pastClimate.getObservations().get(i).values.get(indexDD);
+			futureMeanConstantClimate += (Double) futureClimateUnderConstantClimate.getObservations().get(i).values.get(indexDD);
+			futureMeanRCP4_5 += (Double) futureClimateRCP4_5.getObservations().get(i).values.get(indexDD);
+		}
+		
+		pastMean /= pastClimate.getNumberOfObservations();
+		futureMeanConstantClimate /= futureClimateUnderConstantClimate.getNumberOfObservations();
+		futureMeanRCP4_5 /= futureClimateRCP4_5.getNumberOfObservations();
+
+		Assert.assertEquals("Comparing past and future average degree-days", pastMean, futureMeanConstantClimate, 80);
+		Assert.assertTrue("Testing that future average degrees days under RCP 4.5 are much higher",
+				futureMeanRCP4_5 - futureMeanConstantClimate > 500);
+		
+	}
+	
 	
 	
 }

--- a/test/biosimclient/BioSimWebAPIModelPatches.java
+++ b/test/biosimclient/BioSimWebAPIModelPatches.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the biosimclient library
+ *
+ * Author Mathieu Fortin - Canadian Forest Service
+ * Copyright (C) 2026 His Majesty the King in right of Canada
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package biosimclient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import biosimclient.BioSimEnums.RCP;
+
+public class BioSimWebAPIModelPatches {
+
+	private static List<String> MODELS_WITH_MISSING_INITIAL_YEAR = Arrays.asList(new String[] { "BudBurst", 
+	    "Climate_Mosture_Index_Annual",     // a typo in BioSIM 11
+	    "Gypsy_Moth_Seasonality",
+	    "HemlockWoollyAdelgid_Annual",
+	    "MPB_Cold_Tolerance_Annual",
+	    "MPB_SLR",
+	    "Spruce_Budworm_Biology_Annual",
+	    "SpruceBeetle" });
+
+	private static List<String> MODELS_REQUIRING_MORE_THAN_ONE_YEAR = Arrays.asList(new String[] { "EmeraldAshBorerColdHardiness_Annual",
+	    "HemlockWoollyAdelgid_Daily",
+	    "MPB_Cold_Tolerance_Daily",
+	    "Standardised_Precipitation_Evapotranspiration_Index" });
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void test01ModelsWithMissingInitialYear() throws BioSimClientException, BioSimServerException {
+		System.out.println("Testing models with missing initial year...");
+		List<BioSimPlot> locations = new ArrayList<BioSimPlot>();
+		BioSimPlot refPlot = BioSimClientNormalsTest.getPlots().get(0); 
+		locations.add(refPlot);
+		List<String> models = new ArrayList<String>(MODELS_WITH_MISSING_INITIAL_YEAR);
+		models.add("DegreeDay_Annual");
+		
+		int initYear = 2015;
+		Map<String, Object> pastClimateGeneration = BioSimClient.generateWeather(initYear, 
+				initYear + 5, 
+				locations, 
+				RCP.CONSTANT_CLIMATE, 
+				null, 
+				models, 
+				null);
+		
+		for (String model : models) {
+			System.out.println("    Testing model " + model + "...");
+			if (!model.equals("MPB_SLR")) {
+				LinkedHashMap<BioSimPlot, BioSimDataSet> modelOutput = (LinkedHashMap<BioSimPlot, BioSimDataSet>) pastClimateGeneration.get(model);
+				BioSimDataSet modelOutputForThisPlot = modelOutput.get(refPlot);
+				int yearIndex = modelOutputForThisPlot.getFieldNames().indexOf("Year");
+				if (yearIndex == -1) {
+					throw new UnsupportedOperationException("Cannot find field year in BioSimDataSet instance!");
+				}
+				Assert.assertEquals("Testing that first year is " + initYear + " for model " + model, 
+						initYear,
+						(int) modelOutputForThisPlot.getObservations().get(0).values.get(yearIndex));
+			}
+		}
+		
+		System.out.println("Done.");
+	}
+	
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void test02ModelsRequiringMoreThanOneYear() throws BioSimClientException, BioSimServerException {
+		System.out.println("Testing models requiring more than one year in their MTS...");
+		List<BioSimPlot> locations = new ArrayList<BioSimPlot>();
+		BioSimPlot refPlot = BioSimClientNormalsTest.getPlots().get(0); 
+		locations.add(refPlot);
+		List<String> models = new ArrayList<String>(MODELS_REQUIRING_MORE_THAN_ONE_YEAR);
+		models.add("DegreeDay_Annual");
+		
+		int initYear = 2015;
+		Map<String, Object> pastClimateGeneration = BioSimClient.generateWeather(initYear, 
+				initYear, 
+				locations, 
+				RCP.CONSTANT_CLIMATE, 
+				null, 
+				models, 
+				null);
+		
+		for (String model : models) {
+			System.out.println("    Testing model " + model + "...");
+				LinkedHashMap<BioSimPlot, BioSimDataSet> modelOutput = (LinkedHashMap<BioSimPlot, BioSimDataSet>) pastClimateGeneration.get(model);
+				BioSimDataSet modelOutputForThisPlot = modelOutput.get(refPlot);
+				int yearIndex = modelOutputForThisPlot.getFieldNames().indexOf("Year");
+				if (yearIndex == -1) {
+					throw new UnsupportedOperationException("Cannot find field year in BioSimDataSet instance!");
+				}
+				Assert.assertEquals("Testing that first year is " + initYear + " for model " + model, 
+						initYear,
+						(int) modelOutputForThisPlot.getObservations().get(0).values.get(yearIndex));
+		}
+		
+		System.out.println("Done.");
+	}
+
+	
+}


### PR DESCRIPTION
Models with missing initial years and models requiring more than one year have been patched on the WebAPI end. 
Tests have been added into the Java client to make sure that the patches were properly implemented.